### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,4 +50,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           extra_plugins: |
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin

--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
     [
       "@semantic-release/commit-analyzer",
       [
-        "@google/semantic-release-replace-plugin",
+        "semantic-release-replace-plugin",
         {
             "replacements": [
             {


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).